### PR TITLE
feat(profile): upload profilne fotografije + preview i avatar u headeru

### DIFF
--- a/gozba-na-klik/src/api/axios.ts
+++ b/gozba-na-klik/src/api/axios.ts
@@ -1,7 +1,14 @@
 import axios from "axios";
 
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+export const API_ORIGIN = API_BASE_URL.replace(/\/api\/?$/i, "");
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: API_BASE_URL,
 });
 
 export default api;
+
+// Morao sam da napravim malu izmenu u ovom fajlu jer mi je trebao
+// "orign" iz backend-a za slike jer
+// VITE_API_BASE_URL pokazuje na /api

--- a/gozba-na-klik/src/api/userService.ts
+++ b/gozba-na-klik/src/api/userService.ts
@@ -1,11 +1,14 @@
 import api from "./axios";
-// const RESOURCE = "/";
 
+export async function uploadUserPhoto(userId: number, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await api.post(`/users/${userId}/photo`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return res.data as { avatarUrl: string };
+}
 
-//to-do login
-
-
-
-//to-do register
-
-
+export async function deleteUserPhoto(userId: number) {
+  await api.delete(`/users/${userId}/photo`);
+}

--- a/gozba-na-klik/src/components/UserAvatar.jsx
+++ b/gozba-na-klik/src/components/UserAvatar.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { API_ORIGIN } from "../api/axios";
+
+function getUser() {
+  try {
+    return JSON.parse(localStorage.getItem("user") || "null");
+  } catch {
+    return null;
+  }
+}
+
+export default function UserAvatar({ size = 36, srcOverride = null }) {
+  const user = getUser();
+  const raw = user?.profilePicture ?? user?.ProfilePicture; // pokriva oba naziva
+  const base = raw
+    ? raw.startsWith("http")
+      ? raw
+      : `${API_ORIGIN}${raw}`
+    : null;
+
+  const src = srcOverride ?? base;
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        overflow: "hidden",
+        background: "#eee",
+      }}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt="me"
+          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        />
+      ) : (
+        <span
+          style={{
+            display: "grid",
+            placeItems: "center",
+            height: "100%",
+            color: "#777",
+            fontSize: 12,
+          }}
+        >
+          no
+        </span>
+      )}
+    </div>
+  );
+}

--- a/gozba-na-klik/src/pages/Customer.jsx
+++ b/gozba-na-klik/src/pages/Customer.jsx
@@ -1,13 +1,144 @@
 import React from "react";
+import { useParams } from "react-router-dom";
+import { uploadUserPhoto, deleteUserPhoto } from "../api/userService";
+import "../styles/index.scss";
+import UserAvatar from "../components/UserAvatar";
 
 const Customer = () => {
+  const { id } = useParams();
+  const userId = Number(id);
 
+  // ucitavanje usera iz localstorage-a (login ga cuva)
+  const [user, setUser] = useState(() => {
+    try {
+      const raw = localStorage.getItem("user");
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  });
 
-    return (
-        <>
-            <h1>Welcome customer</h1>
-        </>
-    )
-}
+  const [file, setFile] = useStae(null);
+  const [busy, setBusy] = useStae(false);
 
-export default Customer
+  const previewUrl = useMemo(
+    () => (file ? URL.createObjectURL(file) : null),
+    [file]
+  );
+
+  function onPick(e) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    if (!["image/jpeg", "image/png"].includes(f.type)) {
+      alert("Dozvoljeno: .jpg ili .png");
+      return;
+    }
+    setFile(f);
+  }
+
+  async function onUpload() {
+    if (!file) return;
+    setBusy(true);
+    try {
+      const { avatarUrl } = await uploadUserPhoto(userId, file);
+
+      //osveziti localstorage
+      const updated = { ...(user || {}), profilePicture: avatarUrl };
+      localStorage.setItem("user", JSON.stringify(updated));
+
+      setUser(updated);
+      setFile(null);
+      alert("Prifilna slika uspesno sacuvana.");
+      window.location.reload();
+    } catch (e) {
+      alert("Greska pri slanju slike.");
+      console.error(e);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDelete() {
+    if (!confirm("Ukloniti profilnu sliku?")) return;
+    setBusy(true);
+    try {
+      await deleteUserPhoto(userId);
+      const updated = { ...(user || {}), profilePicture: null };
+      localStorage.setItem("user", JSON.stringify(updated));
+      setUser(updated);
+      setFile(null);
+      alert("Prfilna slika uklonjena");
+      window.location.reload();
+    } catch (e) {
+      alert("Greska pri uklanjanju.");
+      console.error(e);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <header className="navbar">
+        <div className="navbar-inner container" style={{ fontWeight: 800 }}>
+          Moj profil
+        </div>
+        <UserAvatar />
+      </header>
+      <main className="section">
+        <div className="container" style={{ maxWidth: 680 }}>
+          <div className="card card-pad stack">
+            <h2 style={{ margin: 0 }}>Moj Profil</h2>
+
+            <div className="row" style={{ gap: 24, alignItems: "center" }}>
+              {/* Veliki avatar sa PREVIEW */}
+              <UserAvatar size={120} srcOverride={previewUrl} />
+
+              <div className="stack">
+                <input
+                  type="file"
+                  accept="image/png,img/jpeg"
+                  onChange={onPick}
+                  disabled={busy}
+                />
+                {file && (
+                  <span className="help">
+                    Pregled je priveremen-klikni Upload da bi sacuvao.
+                  </span>
+                )}
+
+                <div className="row">
+                  <button
+                    className="btn btn-primary"
+                    onClick={onUpload}
+                    disabled={!file || busy}
+                  >
+                    {busy ? "Slanje..." : "Upload"}
+                  </button>
+                  <button
+                    className="btn btn-outline"
+                    onClick={() => setFile(null)}
+                    disabled={!file || busy}
+                  >
+                    Otkazi
+                  </button>
+                  <button
+                    className="btn btn-ghost"
+                    onClick={onDelete}
+                    disabled={busy || !user?.profilePicture}
+                  >
+                    Ukloni fotografiju
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Ovde Pero mozes da ubacis logiku za dalje informacije o profilu/adresama/alergenima */}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default Customer;

--- a/gozba-na-klik/src/pages/admin/Admin.jsx
+++ b/gozba-na-klik/src/pages/admin/Admin.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import "../../styles/index.scss";
+import UserAvatar from "../../components/UserAvatar";
 
 const Admin = () => {
   const [open, setOpen] = useState(false);
@@ -18,6 +19,7 @@ const Admin = () => {
           >
             ☰ Menu
           </button>
+          <UserAvatar />
         </div>
         {open && (
           <nav className="container" style={{ position: "relative" }}>

--- a/gozba-na-klik/src/pages/admin/AdminUsers.jsx
+++ b/gozba-na-klik/src/pages/admin/AdminUsers.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { getAllUsers, createUser } from "../../api/adminService";
 import "../../styles/index.scss";
+import UserAvatar from "../../components/UserAvatar";
 
 const AdminUsers = () => {
   const [users, setUsers] = useState([]);
@@ -57,6 +58,7 @@ const AdminUsers = () => {
           >
             {showForm ? "Close form" : "Add new user"}
           </button>
+          <UserAvatar />
         </div>
       </header>
 


### PR DESCRIPTION
_Opis :
Na Customer profilu dodat upload profilne fotografije sa preview-om pre slanja, validacijom tipa (jpg/png) i brisanjem slike. Na uspeh se avatar azurira i u profilu i u headeru . Dodata UserAvatar komponenta i minimalne izmene za API origin._

Sta je uradjeno

**src/components/UserAvatar.jsx**

- Mali, reusable avatar (prima size i opcioni srcOverride za preview).
- Sam gradi puni URL (lepi API_ORIGIN na relativni profilePicture).

**src/pages/Customer.jsx**

- File input (accept="image/png,image/jpeg"), preview preko URL.createObjectURL.
- Upload → POST /users/:id/photo (FormData).
- Na uspeh: azurira localStorage.user.profilePicture + window.location.reload() (najjednostavniji refresh headera).
- Ukloni fotografiju → DELETE /users/:id/photo → placeholder.

**src/api/userService.ts**

- uploadUserPhoto(userId, file) → vraca avatarUrl.
- deleteUserPhoto(userId).

**src/api/axios.ts**

- Export API_ORIGIN izveden iz VITE_API_BASE_URL (skida /api sufiks).